### PR TITLE
Fix bugs in segmentation, show label list after drawing a polygon

### DIFF
--- a/src/components/image-labelling/image-labelling-object-detection/bounding-box-canvas.service.ts
+++ b/src/components/image-labelling/image-labelling-object-detection/bounding-box-canvas.service.ts
@@ -327,7 +327,7 @@ export class BoundingBoxCanvasService {
     ) {
         try {
             for (const box of boxes) {
-                console.log(box);
+                // console.log(box);
                 const newW: number = (box.x2 - box.x1) * scalefactor;
                 const newH: number = (box.y2 - box.y1) * scalefactor;
                 const X1: number = box.distancetoImg.x * scalefactor + imgX;

--- a/src/components/image-labelling/image-labelling-project/image-labelling-project.component.ts
+++ b/src/components/image-labelling/image-labelling-project/image-labelling-project.component.ts
@@ -205,10 +205,9 @@ export class ImageLabellingProjectComponent implements OnInit, OnChanges, OnDest
 
     onClickLabel = (label: string) => {
         this.selectedLabel = label;
-
-        this.selectedIndexAnnotation > -1 &&
-            this._onChangeAnnotationLabel.emit({ label, index: this.selectedIndexAnnotation });
-        this._selectMetadata.bnd_box[this.selectedIndexAnnotation].label = label;
+        // this.selectedIndexAnnotation > -1 &&
+        this._onChangeAnnotationLabel.emit({ label, index: this.selectedIndexAnnotation });
+        // this._selectMetadata.bnd_box[this.selectedIndexAnnotation].label = label;
         this._undoRedoService.appendStages({
             meta: this._selectMetadata,
             method: 'draw',

--- a/src/components/image-labelling/image-labelling-segmentation/image-labelling-segmentation.component.html
+++ b/src/components/image-labelling/image-labelling-segmentation/image-labelling-segmentation.component.html
@@ -1,3 +1,31 @@
 <div>
+    <div #floatdiv class="floatdiv unclosedOut" [hidden]="!showDropdownLabelBox">
+        <form autocomplete="off" spellcheck="false" class="unclosedOut">
+            <input
+                #lbltypetxt
+                type="text"
+                class="lbltypetxt unclosedOut"
+                [(ngModel)]="labelSearch"
+                (ngModelChange)="labelTypeTextChange($event)"
+                [ngModelOptions]="{ standalone: true }"
+            />
+        </form>
+        <div #availablelbl class="availablelbl unclosedOut">
+            <ul class="lblList unclosedOut">
+                <li
+                    *ngFor="let label of labelList"
+                    class="lblElement unclosedOut"
+                    (click)="labelNameClicked(label.name)"
+                >
+                    <span class="lblName unclosedOut">{{ label.name }}</span>
+                    <span class="lblCount unclosedOut">{{ label.count }}</span>
+                </li>
+                <li *ngIf="labelList.length === 0" class="unclosedOut notExist">
+                    <div class="unclosedOut">{{ 'searchLabel.labelNotExist' | translate }}</div>
+                    <div class="unclosedOut">{{ 'searchLabel.enterToAdd' | translate }}</div>
+                </li>
+            </ul>
+        </div>
+    </div>
     <canvas #canvasdrawing class="canvasstyle" [ngStyle]="{ cursor: currentCursor() }"></canvas>
 </div>

--- a/src/components/image-labelling/image-labelling-segmentation/image-labelling-segmentation.component.scss
+++ b/src/components/image-labelling/image-labelling-segmentation/image-labelling-segmentation.component.scss
@@ -10,3 +10,83 @@
     outline: none;
     border: none;
 }
+
+.floatdiv {
+    position: absolute;
+    z-index: 10000;
+}
+
+.availablelbl {
+    background-color: black;
+    width: 11vw;
+    height: 15vh;
+    color: snow;
+    font-size: 2vh;
+    font-weight: bold;
+    border: 0.2vw solid gray;
+    outline: none;
+    border-radius: 0.2vh;
+    border-top: 0.1vh dotted snow;
+    // text-align: center;
+    overflow: auto;
+    scrollbar-width: none;
+    &::-webkit-scrollbar {
+        display: none;
+    }
+}
+
+.lblList {
+    padding: 0 0.2vw;
+}
+
+.lblElement {
+    list-style-type: none;
+    margin: 0.3vh 0;
+    padding: 0;
+    justify-content: space-between;
+    display: flex;
+    &:hover {
+        background-color: #111;
+    }
+}
+
+.lblName {
+    margin-left: 0.2vw;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.lblCount {
+    background-color: #222;
+    margin-right: 0.2vw;
+    padding: 0.1vh 0.2vw;
+    border-radius: 0.2vw;
+}
+
+.notExist {
+    color: #999;
+    font-size: 1.5vh;
+}
+
+.lbltypetxt {
+    width: 11vw;
+    height: 4vh;
+    color: snow;
+    font-size: 2vh;
+    // font-weight: bold;
+    border: 0.2vw solid gray;
+    background-color: black;
+    outline: none;
+    border-radius: 0.2vh;
+    border-bottom: none;
+    padding: 0;
+    text-indent: 0.4vw;
+}
+
+.invalidInput {
+    border: 0.2vw solid red;
+}
+
+.validInput {
+    border: 0.2vw solid grey;
+}

--- a/src/components/image-labelling/image-labelling-segmentation/image-labelling-segmentation.component.ts
+++ b/src/components/image-labelling/image-labelling-segmentation/image-labelling-segmentation.component.ts
@@ -48,6 +48,9 @@ import {
 })
 export class ImageLabellingSegmentationComponent implements OnInit, OnChanges, OnDestroy {
     @ViewChild('canvasdrawing') canvas!: ElementRef<HTMLCanvasElement>;
+    @ViewChild('floatdiv') floatdiv!: ElementRef<HTMLDivElement>;
+    @ViewChild('lbltypetxt') lbltypetxt!: ElementRef<HTMLInputElement>;
+    @ViewChild('availablelbl') availablelbl!: ElementRef<HTMLDivElement>;
     private canvasContext!: CanvasRenderingContext2D;
     private image: HTMLImageElement = new Image();
     private isMouseWithinPoint: boolean = false;
@@ -281,7 +284,6 @@ export class ImageLabellingSegmentationComponent implements OnInit, OnChanges, O
                         : []
                     : [];
                 this.sortingLabelList(this.labelList, annotationList);
-                this.showDropdownLabelBox = true;
                 this._segCanvasService.drawNewPolygon(
                     this._selectMetadata,
                     this.image,
@@ -289,6 +291,7 @@ export class ImageLabellingSegmentationComponent implements OnInit, OnChanges, O
                     this.canvas.nativeElement,
                     true,
                 );
+                this.positioningLabelListPopup(this._selectMetadata.polygons);
                 this._segCanvasService.validateXYDistance(this._selectMetadata);
                 this.redrawImage(this._selectMetadata);
                 this.emitMetadata();
@@ -316,7 +319,6 @@ export class ImageLabellingSegmentationComponent implements OnInit, OnChanges, O
                                     : []
                                 : [];
                             this.sortingLabelList(this.labelList, annotationList);
-                            this.showDropdownLabelBox = true;
                             this._segCanvasService.drawNewPolygon(
                                 this._selectMetadata,
                                 this.image,
@@ -324,6 +326,7 @@ export class ImageLabellingSegmentationComponent implements OnInit, OnChanges, O
                                 this.canvas.nativeElement,
                                 true,
                             );
+                            this.positioningLabelListPopup(this._selectMetadata.polygons);
                             this.annotateStateChange({ annotation: this._selectMetadata.polygons.length - 1 });
                             // this._segCanvasService.setSelectedPolygon(annotation);
                             this._segCanvasService.validateXYDistance(this._selectMetadata);
@@ -483,6 +486,7 @@ export class ImageLabellingSegmentationComponent implements OnInit, OnChanges, O
                     this.redrawImage(this._selectMetadata);
                 }
                 if (this.segState.draw) {
+                    this.showDropdownLabelBox = false;
                     // needed when mouse down then mouse move to get correct coordinate
                     const polyIndex = this._segCanvasService.mouseDownDraw(
                         event,
@@ -689,6 +693,41 @@ export class ImageLabellingSegmentationComponent implements OnInit, OnChanges, O
 
     currentCursor() {
         return this._mouseCursorService.changeCursor(this.mouseCursor);
+    }
+
+    positioningLabelListPopup(polygons: Polygons[]) {
+        const offsetX =
+            polygons[this._selectMetadata.polygons.length - 1].coorPt[
+                this._selectMetadata.polygons[this._selectMetadata.polygons.length - 1].coorPt.length - 1
+            ].x;
+        const offsetY =
+            polygons[this._selectMetadata.polygons.length - 1].coorPt[
+                this._selectMetadata.polygons[this._selectMetadata.polygons.length - 1].coorPt.length - 1
+            ].y;
+        // Positioning the floating div at the bottom right corner of bounding box
+        let posFromTop = offsetY * (100 / document.documentElement.clientHeight) + 8.5;
+        let posFromLeft = offsetX * (100 / document.documentElement.clientWidth) + 2.5;
+        // Re-adjustment of floating div position if it is outside of the canvas
+        if (posFromTop < 9) {
+            posFromTop = 9;
+        }
+        if (posFromTop > 76) {
+            posFromTop = 76;
+        }
+        if (posFromLeft < 2.5) {
+            posFromLeft = 2.5;
+        }
+        if (posFromLeft > 66) {
+            posFromLeft = 66;
+        }
+        this.floatdiv.nativeElement.style.top = posFromTop.toString() + 'vh';
+        this.floatdiv.nativeElement.style.left = posFromLeft.toString() + 'vw';
+        this.showDropdownLabelBox = true;
+        this.labelSearch = '';
+        // this.invalidInput = false;
+        setTimeout(() => {
+            this.lbltypetxt.nativeElement.focus();
+        }, 100);
     }
 
     getLabelList() {

--- a/src/components/image-labelling/image-labelling-segmentation/image-labelling-segmentation.component.ts
+++ b/src/components/image-labelling/image-labelling-segmentation/image-labelling-segmentation.component.ts
@@ -102,6 +102,9 @@ export class ImageLabellingSegmentationComponent implements OnInit, OnChanges, O
     }
 
     ngOnChanges(changes: SimpleChanges): void {
+        if (changes._selectMetadata?.previousValue && changes._selectMetadata?.currentValue) {
+            this.redrawImage(this._selectMetadata);
+        }
         if (changes._imgSrc?.currentValue) {
             this.initializeCanvas();
             this._undoRedoService.clearAllStages();

--- a/src/components/image-labelling/image-labelling-segmentation/image-labelling-segmentation.component.ts
+++ b/src/components/image-labelling/image-labelling-segmentation/image-labelling-segmentation.component.ts
@@ -277,13 +277,6 @@ export class ImageLabellingSegmentationComponent implements OnInit, OnChanges, O
     canvasDblClickEvent(_: MouseEvent) {
         if (this.validateEndDrawPolygon(this.segState, this.isMouseWithinPoint, this.canvasContext)) {
             if (this._segCanvasService.isNewPolygon()) {
-                this.getLabelList();
-                const annotationList = this._tabStatus[2].annotation
-                    ? this._tabStatus[2].annotation[0].polygons
-                        ? this._tabStatus[2].annotation[0].polygons
-                        : []
-                    : [];
-                this.sortingLabelList(this.labelList, annotationList);
                 this._segCanvasService.drawNewPolygon(
                     this._selectMetadata,
                     this.image,
@@ -312,13 +305,6 @@ export class ImageLabellingSegmentationComponent implements OnInit, OnChanges, O
                     const { annotation } = this.annotateState;
                     switch (key) {
                         case 'Enter':
-                            this.getLabelList();
-                            const annotationList = this._tabStatus[2].annotation
-                                ? this._tabStatus[2].annotation[0].polygons
-                                    ? this._tabStatus[2].annotation[0].polygons
-                                    : []
-                                : [];
-                            this.sortingLabelList(this.labelList, annotationList);
                             this._segCanvasService.drawNewPolygon(
                                 this._selectMetadata,
                                 this.image,
@@ -486,6 +472,13 @@ export class ImageLabellingSegmentationComponent implements OnInit, OnChanges, O
                     this.redrawImage(this._selectMetadata);
                 }
                 if (this.segState.draw) {
+                    this.getLabelList();
+                    const annotationList = this._tabStatus[2].annotation
+                        ? this._tabStatus[2].annotation[0].polygons
+                            ? this._tabStatus[2].annotation[0].polygons
+                            : []
+                        : [];
+                    this.sortingLabelList(this.labelList, annotationList);
                     this.showDropdownLabelBox = false;
                     // needed when mouse down then mouse move to get correct coordinate
                     const polyIndex = this._segCanvasService.mouseDownDraw(
@@ -496,6 +489,7 @@ export class ImageLabellingSegmentationComponent implements OnInit, OnChanges, O
                         this.canvasContext,
                         this.ctrlKey,
                         this.altKey,
+                        this.labelList,
                     );
 
                     if (polyIndex > -1) {

--- a/src/components/image-labelling/image-labelling-segmentation/image-labelling-segmentation.component.ts
+++ b/src/components/image-labelling/image-labelling-segmentation/image-labelling-segmentation.component.ts
@@ -136,7 +136,7 @@ export class ImageLabellingSegmentationComponent implements OnInit, OnChanges, O
             this.imgFitToCenter();
             this.emitMetadata();
             this.changeMouseCursorState();
-            this._undoRedoService.appendStages({ meta: cloneDeep(this._selectMetadata), method: 'draw' });
+            // this._undoRedoService.appendStages({ meta: cloneDeep(this._selectMetadata), method: 'draw' });
         };
     }
 
@@ -296,6 +296,10 @@ export class ImageLabellingSegmentationComponent implements OnInit, OnChanges, O
                             //     stage: this.seg.Metadata[this.seg.getCurrentSelectedimgidx()],
                             //     method: 'draw',
                             // });
+                            this._undoRedoService.appendStages({
+                                meta: cloneDeep(this._selectMetadata),
+                                method: 'draw',
+                            });
                             this.redrawImage(this._selectMetadata);
                             this.emitMetadata();
                             break;
@@ -343,46 +347,46 @@ export class ImageLabellingSegmentationComponent implements OnInit, OnChanges, O
                 direction && this.keyMoveBox(direction);
                 // this.canvasContext.canvas.focus();
             }
-            if (!this.isMouseWithinPoint) {
-                if (ctrlKey && (key === 'c' || key === 'C')) {
-                    // copy
-                    this.annotateState.annotation > -1 &&
-                        this._copyPasteService.copy(this._selectMetadata.polygons[this.annotateState.annotation]);
-                } else if (ctrlKey && (key === 'v' || key === 'V')) {
-                    // paste
-                    if (this._copyPasteService.isAvailable()) {
-                        this._selectMetadata.polygons.push(this._copyPasteService.paste() as Polygons);
-                        // this.rulesMakeChange(null, this._selectMetadata.bnd_box.length - 1, null, null, null),
-                        this.annotateStateChange({
-                            annotation: this._selectMetadata.polygons.length - 1,
-                        });
-                        this._segCanvasService.validateXYDistance(this._selectMetadata);
-                    }
-
-                    this._undoRedoService.appendStages({
-                        meta: cloneDeep(this._selectMetadata),
-                        method: 'draw',
+            // if (!this.isMouseWithinPoint) {
+            if (ctrlKey && (key === 'c' || key === 'C')) {
+                // copy
+                this.annotateState.annotation > -1 &&
+                    this._copyPasteService.copy(this._selectMetadata.polygons[this.annotateState.annotation]);
+            } else if (ctrlKey && (key === 'v' || key === 'V')) {
+                // paste
+                if (this._copyPasteService.isAvailable()) {
+                    this._selectMetadata.polygons.push(this._copyPasteService.paste() as Polygons);
+                    // this.rulesMakeChange(null, this._selectMetadata.bnd_box.length - 1, null, null, null),
+                    this.annotateStateChange({
+                        annotation: this._selectMetadata.polygons.length - 1,
                     });
+                    this._segCanvasService.validateXYDistance(this._selectMetadata);
+                }
+
+                this._undoRedoService.appendStages({
+                    meta: cloneDeep(this._selectMetadata),
+                    method: 'draw',
+                });
+                this.emitMetadata();
+                // this.canvas.nativeElement.focus();
+            } else if (ctrlKey && shiftKey && (key === 'z' || key === 'Z')) {
+                // redo
+                if (this._undoRedoService.isAllowRedo()) {
+                    const rtStages: UndoState = this._undoRedoService.redo();
+                    this._selectMetadata = cloneDeep(rtStages?.meta as PolyMetadata);
+                    this.redrawImage(this._selectMetadata);
                     this.emitMetadata();
-                    // this.canvas.nativeElement.focus();
-                } else if (ctrlKey && shiftKey && (key === 'z' || key === 'Z')) {
-                    // redo
-                    if (this._undoRedoService.isAllowRedo()) {
-                        const rtStages: UndoState = this._undoRedoService.redo();
-                        this._selectMetadata = cloneDeep(rtStages?.meta as PolyMetadata);
-                        this.redrawImage(this._selectMetadata);
-                        this.emitMetadata();
-                    }
-                } else if (ctrlKey && (key === 'z' || key === 'Z')) {
-                    // undo
-                    if (this._undoRedoService.isAllowUndo()) {
-                        const rtStages: UndoState = this._undoRedoService.undo();
-                        this._selectMetadata = cloneDeep(rtStages?.meta as PolyMetadata);
-                        this.redrawImage(this._selectMetadata);
-                        this.emitMetadata();
-                    }
+                }
+            } else if (ctrlKey && (key === 'z' || key === 'Z')) {
+                // undo
+                if (this._undoRedoService.isAllowUndo()) {
+                    const rtStages: UndoState = this._undoRedoService.undo();
+                    this._selectMetadata = cloneDeep(rtStages?.meta as PolyMetadata);
+                    this.redrawImage(this._selectMetadata);
+                    this.emitMetadata();
                 }
             }
+            // }
         } catch (err) {
             console.log('canvasKeyDownEvent', err);
         }

--- a/src/components/image-labelling/image-labelling-segmentation/image-labelling-segmentation.component.ts
+++ b/src/components/image-labelling/image-labelling-segmentation/image-labelling-segmentation.component.ts
@@ -209,11 +209,7 @@ export class ImageLabellingSegmentationComponent implements OnInit, OnChanges, O
         this.canvasContext.drawImage(this.image, img_x, img_y, img_w, img_h);
         if (this._tabStatus[2].annotation?.length !== 0) {
             this.getLabelList();
-            const annotationList = this._tabStatus[2].annotation
-                ? this._tabStatus[2].annotation[0].polygons
-                    ? this._tabStatus[2].annotation[0].polygons
-                    : []
-                : [];
+            const annotationList = this._tabStatus[2].annotation ? this._tabStatus[2].annotation[0].polygons ?? [] : [];
             this.sortingLabelList(this.labelList, annotationList);
         }
         this._segCanvasService.drawAllPolygon(this._selectMetadata, this.canvasContext, this.annotateState.annotation);
@@ -474,9 +470,7 @@ export class ImageLabellingSegmentationComponent implements OnInit, OnChanges, O
                 if (this.segState.draw) {
                     this.getLabelList();
                     const annotationList = this._tabStatus[2].annotation
-                        ? this._tabStatus[2].annotation[0].polygons
-                            ? this._tabStatus[2].annotation[0].polygons
-                            : []
+                        ? this._tabStatus[2].annotation[0].polygons ?? []
                         : [];
                     this.sortingLabelList(this.labelList, annotationList);
                     this.showDropdownLabelBox = false;
@@ -672,7 +666,7 @@ export class ImageLabellingSegmentationComponent implements OnInit, OnChanges, O
                 !(event.relatedTarget as Element)?.className.includes('canvasstyle')
             ) {
                 this.showDropdownLabelBox = false;
-                if (this._selectMetadata.polygons.filter((poly) => poly.label === '').length !== 0) {
+                if (this._selectMetadata.polygons.filter((poly) => !poly.label).length !== 0) {
                     this._selectMetadata.polygons = this._selectMetadata.polygons.filter((poly) => poly.label !== '');
                     this._onChangeMetadata.emit(this._selectMetadata);
                     this.redrawImage(this._selectMetadata);
@@ -727,15 +721,13 @@ export class ImageLabellingSegmentationComponent implements OnInit, OnChanges, O
     getLabelList() {
         this.labelList = [];
         this.allLabelList = [];
-        (this._tabStatus[1].label_list ? this._tabStatus[1].label_list : []).forEach((name: string) => {
-            this.labelList.push({
+        (this._tabStatus[1].label_list ?? []).forEach((name: string) => {
+            const labels = {
                 name,
                 count: 0,
-            });
-            this.allLabelList.push({
-                name,
-                count: 0,
-            });
+            };
+            this.labelList.push(labels);
+            this.allLabelList.push(labels);
         });
     }
 

--- a/src/components/image-labelling/image-labelling-segmentation/segmentation-canvas.service.ts
+++ b/src/components/image-labelling/image-labelling-segmentation/segmentation-canvas.service.ts
@@ -1,3 +1,4 @@
+import { LabelInfo } from './../image-labelling.model';
 /**
  * @license
  * Use of this source code is governed by Apache License 2.0 that can be
@@ -37,6 +38,7 @@ export class SegmentationCanvasService {
     private selectedPolygonIndex: number = -1;
     private util: Utils = new Utils();
     private isNewPoly: boolean = false;
+    private labelList: LabelInfo[] = [];
     // private currentSelectedImg = { uid: -1, idx: -1 };
 
     constructor() {}
@@ -49,7 +51,9 @@ export class SegmentationCanvasService {
         context: CanvasRenderingContext2D,
         ctrlKey: boolean,
         altKey: boolean,
+        labelList: LabelInfo[],
     ): number {
+        this.labelList = labelList;
         const { offsetX, offsetY } = event;
         this.polygonAreaIndex = this.findPolygonArea(event, metadata);
         this.clickPoint = this.findClickPoint(offsetX, offsetY, metadata);
@@ -244,7 +248,7 @@ export class SegmentationCanvasService {
             const tmpRegion: string = (len + 1).toString();
             this.tmpPolygon = {
                 coorPt: [],
-                label: 'default',
+                label: this.labelList.length > 0 ? this.labelList[0].name : '',
                 id: uuid,
                 lineWidth: 2,
                 color: 'rgba(0,255,0,1.0)',

--- a/src/components/image-labelling/image-labelling-segmentation/segmentation-canvas.service.ts
+++ b/src/components/image-labelling/image-labelling-segmentation/segmentation-canvas.service.ts
@@ -247,7 +247,7 @@ export class SegmentationCanvasService {
                 label: 'default',
                 id: uuid,
                 lineWidth: 2,
-                color: '#FFFAFA',
+                color: 'rgba(0,255,0,1.0)',
                 region: tmpRegion,
                 subLabel: [],
             };
@@ -549,6 +549,7 @@ export class SegmentationCanvasService {
             metadata.polygons = metadata.polygons.map((poly, i) => ({
                 ...poly,
                 lineWidth: i === polyIndex ? (poly.lineWidth = 2) : (poly.lineWidth = 1),
+                color: i === polyIndex ? (poly.color = 'rgba(0,255,0,1.0)') : (poly.color = 'rgba(255,255,0,0.8)'),
             }));
         } catch (err) {
             console.log('setPolygonLineWidth', err);
@@ -595,7 +596,7 @@ export class SegmentationCanvasService {
                     const { length } = pol.polygons;
                     if (this.tmpPolygon) {
                         pol.polygons.push(cloneDeep(this.tmpPolygon));
-                        this.setPolygonLineWidth(pol, length - 1);
+                        this.setPolygonLineWidth(pol, length);
                         this.tmpPolygon = null;
                     }
                     this.setNewPolygon(false);

--- a/src/layouts/image-labelling-layout/image-labelling-layout.component.html
+++ b/src/layouts/image-labelling-layout/image-labelling-layout.component.html
@@ -31,7 +31,9 @@
             <image-labelling-segmentation
                 [_selectMetadata]="selectedMetaData"
                 [_imgSrc]="imgSrc"
+                [_tabStatus]="tabStatus"
                 (_onChangeMetadata)="onChangeMetadata($event)"
+                (_onChangeAnnotationLabel)="onChangeAnnotationLabel($event)"
             ></image-labelling-segmentation>
         </ng-container>
 

--- a/src/layouts/image-labelling-layout/image-labelling-layout.component.ts
+++ b/src/layouts/image-labelling-layout/image-labelling-layout.component.ts
@@ -601,6 +601,7 @@ export class ImageLabellingLayoutComponent implements OnInit, OnDestroy {
     };
 
     onChangeAnnotationLabel = (changeAnnoLabel: ChangeAnnotationLabel): void => {
+        changeAnnoLabel.index = this.currentAnnotationIndex;
         this.tabStatus = this._imgLblLayoutService.changeAnnotationLabel(this.tabStatus, changeAnnoLabel);
         this.updateStateToRenderChild();
         this.updateProjectProgress();

--- a/src/layouts/image-labelling-layout/image-labelling-layout.component.ts
+++ b/src/layouts/image-labelling-layout/image-labelling-layout.component.ts
@@ -602,6 +602,14 @@ export class ImageLabellingLayoutComponent implements OnInit, OnDestroy {
 
     onChangeAnnotationLabel = (changeAnnoLabel: ChangeAnnotationLabel): void => {
         changeAnnoLabel.index = this.currentAnnotationIndex;
+        if (this.selectedMetaData) {
+            // if (this.selectedMetaData.bnd_box) {
+            //   this.selectedMetaData.bnd_box[changeAnnoLabel.index].label = changeAnnoLabel.label;
+            // }
+            if (this.selectedMetaData.polygons) {
+                this.selectedMetaData.polygons[changeAnnoLabel.index].label = changeAnnoLabel.label;
+            }
+        }
         this.tabStatus = this._imgLblLayoutService.changeAnnotationLabel(this.tabStatus, changeAnnoLabel);
         this.updateStateToRenderChild();
         this.updateProjectProgress();

--- a/src/shared/services/undo-redo.service.ts
+++ b/src/shared/services/undo-redo.service.ts
@@ -29,6 +29,14 @@ export class UndoRedoService {
 
     constructor() {}
 
+    public getCurrentArray() {
+        return {
+            undoArr: this.undoArr,
+            redoArr: this.redoArr,
+            curr: this.currentArr,
+        };
+    }
+
     private removeLastArray = (arr: UndoState[]): UndoState => arr.splice(-1, 1)[0];
 
     public appendStages(stages: UndoState): void {
@@ -180,10 +188,10 @@ export class UndoRedoService {
                     for (const [i, { x1, x2, y1, y2, label }] of thisBox.entries()) {
                         // if condition is true, stop the loop and return true
                         if (
-                            x1 !== compareBox[i].x1 ||
-                            x2 !== compareBox[i].x2 ||
-                            y1 !== compareBox[i].y1 ||
-                            y2 !== compareBox[i].y2 ||
+                            Math.ceil(x1) !== Math.ceil(compareBox[i].x1) ||
+                            Math.ceil(x2) !== Math.ceil(compareBox[i].x2) ||
+                            Math.ceil(y1) !== Math.ceil(compareBox[i].y1) ||
+                            Math.ceil(y2) !== Math.ceil(compareBox[i].y2) ||
                             label !== compareBox[i].label
                         ) {
                             return true;


### PR DESCRIPTION
# Description
- Change polygon line color
  - Before: white , white & bold when selected
  - After: yellow, green & bold when selected
- Fix change label in segmentation
- Fix undo & redo in segmentation
- Label list shows up after done drawing polygon.
- Remove 'default' label in segmentation

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tested on?

- [x] Windows  
- [ ] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  

# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged