### PR TITLE
Disable Exit using Esc Key when create/import project

### DIFF
--- a/src/components/modal/modal.component.ts
+++ b/src/components/modal/modal.component.ts
@@ -78,6 +78,8 @@ export class ModalComponent implements OnInit, OnDestroy {
 
     @HostListener('window:keydown', ['$event'])
     keyDownEvent = ({ key }: KeyboardEvent): void => {
-        key === 'Escape' && this.close();
+        if (this.id !== 'modal-create-project' && this.id !== 'modal-import-project') {
+            key === 'Escape' && this.close();
+        }
     };
 }


### PR DESCRIPTION
# Description

Disable the ability to exit modal when creating/importing a project.

Fixes # (issue)
0.08: pressed esc
0.16: pressed esc

https://user-images.githubusercontent.com/81958029/121648523-2e10f580-caca-11eb-9365-9cd909898443.mp4

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tested on?

- [x] Windows  
- [ ] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged