### PR TITLE
Updated copy workflow to add auto code compiler

### DIFF
--- a/.github/workflows/copy.yml
+++ b/.github/workflows/copy.yml
@@ -3,13 +3,47 @@ on:
   push:
     branches: main
 
-    paths:
-      # Triggered when only this path has code changes during push
-      - 'dist/classifai/**'
-
 jobs:
+  build:
+    name: Build Node.js
+    runs-on: ubuntu-latest
+    steps:
+    - name: Get latest code
+      uses: actions/checkout@v2
+      with:
+        token: ${{ secrets.PERSONAL_TOKEN }}
+
+    - name: Use Node.js 14 LTS
+      uses: actions/setup-node@v2
+      with:
+        node-version: '14'
+
+    - name: Caching Dependencies
+      uses: actions/cache@v2
+      with:
+        # npm cache files are stored in `~/.npm` on Linux/macOS
+        path: ~/.npm
+        key: ${{ runner.OS }}-node-${{ hashFiles('**/package-lock.json') }}
+        restore-keys: |
+          ${{ runner.OS }}-node-
+          ${{ runner.OS }}-
+      
+    - name: Install NPM Modules
+      run: npm install
+
+    - name: Build Project
+      run: npm run build:normal
+
+    # Commit the compiled codes in the cloud back into the repo
+    - name: Auto-commit compiled codes
+      uses: stefanzweifel/git-auto-commit-action@v4
+      with:
+        commit_message: ":package: Updated compiled codes"
+        file_pattern: "dist/" # Only commit contents of dist folder / Similar to git add command
+
   copy:
     name: Copy job
+    needs: build
     runs-on: ubuntu-latest
     steps:
       - name: Declaring output variable # Necessary to call PR's URL


### PR DESCRIPTION
# Description

## Details

- Added auto compiler feature in copy workflow to ease Frontend team.
- They do not need to compile their codes anymore so that they can just focus on developing the source codes.
- The flow of the updated workflow will be as below:

1) Dev team's PRs merge with the main branch.
2) The auto compiler workflow will kick in & start due to push codes event at the main branch.
3) Auto compiler workflow will copy/checkout the latest codes at that point of time from the main branch into GitHub Action's cloud.
4) It will start to build & compile the codes & put it into dist folder.
5) The compiled codes will be committed from the cloud back into the repo's main branch. (only contents of dist folder will be recommitted, other artifacts produced in the cloud will be ignored & discarded)
6) Then, the copy job will start to copy contents of dist folder into the backend side, hence triggering the auto PR workflow as expected.

***RESULT***
- Compiled code tested at backend side with two multiple frontend PRs worked for different features.
- Shown that the compiled codes copied from the frontend are working without need the developers to compile their codes first prior PR merged.

<img width="1532" alt="Screenshot 2021-06-23 at 12 47 10 PM" src="https://user-images.githubusercontent.com/83570177/123051951-de6ceb00-d434-11eb-964f-db3fda281e1d.png">

## Limitation

***FIRST PR's URL MIGHT NOT BE SHOWN AT BACKEND'S AUTO PR***

- With multiple frontend PRs approved in short time, this cause multiple auto compiler workflow to be triggered. 
- Because of this, such effect as below can be happen at the auto PR. The first committed frontend PR's URL is missing. (In diagram below, ignore the previous commits)

![image](https://user-images.githubusercontent.com/83570177/123054754-c21e7d80-d437-11eb-9492-414df17f1b91.png)

- This happen because the multiple frontend PRs have been merged in short time, thus causing a failure at auto commit function in the workflow for the first PR's triggered workflow. Error in the workflow triggered as below:

![image](https://user-images.githubusercontent.com/83570177/123055474-833cf780-d438-11eb-8352-c23835b087ad.png)

- In normal behaviour (when distance of two different PRs merged more than **3 minutes**), it would look like below, the workflow triggered from PR A managed to complete its action first before the second PR, PR B, merged into the main branch. This will not cause any conflicts to the workflow.

<img width="2384" alt="Screenshot 2021-06-23 at 3 42 46 PM" src="https://user-images.githubusercontent.com/83570177/123057866-d021cd80-d43a-11eb-8e9c-9b8909a5318b.png">

- If the two PRs merged less than 3 minutes, it will cause conflict at the first workflow as shown previously. In the first workflow, triggered from PR A, it will try to commit the compiled codes from the cloud back into the main branch. If PR B has been merged into the main branch before the first workflow completed its actions/jobs, this will cause the conflict as it does not have the information that the main branch has at the point of time (after merging with PR B). Since the first workflow, only contain information/codes from the time PR A got merged. Diagram as below:

![image](https://user-images.githubusercontent.com/83570177/123063085-adde7e80-d43f-11eb-9e06-af57b9fa62b7.png)
 
- Why 3 minutes ? It is because average time to complete a copy workflow takes about 3 minutes.

![image](https://user-images.githubusercontent.com/83570177/123063647-30673e00-d440-11eb-844d-9a5f93b5f336.png)

- Fortunately, this would not cause a major issue. The compiled codes from the second workflow still contain source codes from both of the PRs, even the first workflow failed due to the mentioned conflict.
- It only cause the first frontend PR's URL missing at the backend auto PR

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [X] Adding GitHub Action capabilities

# Tested on?

- [ ] Windows  
- [ ] Linux Ubuntu 
- [ ] Centos 
- [X] Mac  
- [ ] Others  (State here -> xxx )  

# Checklist:

- [ ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged