### PR TITLE
Show the project list based on the chosen category at side menu in Dataset Management page.

### DIFF
--- a/src/components/data-set/data-set-header/data-set-header.component.html
+++ b/src/components/data-set/data-set-header/data-set-header.component.html
@@ -8,6 +8,7 @@
             <option value="last_modified_date">Last Modified Date</option>
         </select>
     </div>
+    <div *ngIf="!_enableSort" style="height: 3.5vh"></div>
     <div class="dataset-icon-container">
         <!-- <ng-container *ngFor="let icon of jsonSchema.icons">
             <img class="dataset-icon" [src]="icon.imgPath" [title]="icon.hoverLabel" [alt]="icon.alt" />

--- a/src/components/data-set/data-set-header/data-set-header.component.html
+++ b/src/components/data-set/data-set-header/data-set-header.component.html
@@ -1,8 +1,8 @@
 <div class="dataset-header-container">
     <label class="label" style="padding-right: 50vw">{{ 'datasetHeader.datasetManagement' | translate }}</label>
-    <div class="dataset-dropdown-container">
+    <div class="dataset-dropdown-container" *ngIf="_enableSort">
         <label class="dropdown-title">Sort By: </label>
-        <select class="dropdown" (change)="onOptionsSelected(mySelect.value)" #mySelect>
+        <select class="dropdown" [value]="selectedOpt" (change)="onOptionsSelected(mySelect.value)" #mySelect>
             <option value="project_name">Project Name</option>
             <option value="created_date">Created Date</option>
             <option value="last_modified_date">Last Modified Date</option>

--- a/src/components/data-set/data-set-header/data-set-header.component.ts
+++ b/src/components/data-set/data-set-header/data-set-header.component.ts
@@ -4,7 +4,7 @@
  * found in the LICENSE file at https://github.com/CertifaiAI/Classifai_FrontEnd/blob/main/LICENSE
  */
 
-import { Component, EventEmitter, OnInit, Output } from '@angular/core';
+import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 
 @Component({
     selector: 'data-set-header',
@@ -13,6 +13,8 @@ import { Component, EventEmitter, OnInit, Output } from '@angular/core';
 })
 export class DataSetHeaderComponent implements OnInit {
     @Output() selectedKey = new EventEmitter<string>();
+    @Input() _enableSort: boolean = true;
+    selectedOpt: string = 'project_name';
 
     // optionLists: string[] = ['status', 'name', 'date', 'starred'];
     // jsonSchema!: IconSchema;
@@ -42,6 +44,7 @@ export class DataSetHeaderComponent implements OnInit {
     ngOnInit(): void {}
 
     onOptionsSelected(value: string) {
+        this.selectedOpt = value;
         this.selectedKey.emit(value);
     }
 

--- a/src/components/data-set/data-set-side-menu/data-set-side-menu.component.html
+++ b/src/components/data-set/data-set-side-menu/data-set-side-menu.component.html
@@ -11,7 +11,12 @@
 
         <ng-template #otherMenu>
             <!-- <div class="current-project-container"> -->
-            <div [attr.data-index]="i" class="current-project-btn" (click)="onClickButton(menu.id)">
+            <div
+                [attr.data-index]="i"
+                class="current-project-btn"
+                [class.active]="menu.id === selectedId"
+                (click)="onClickButton(menu.id)"
+            >
                 <img class="project-icon" [src]="menu.src" [style]="menu.style" />
                 <label class="current-project-txt">{{ menu.name | translate }}</label>
             </div>

--- a/src/components/data-set/data-set-side-menu/data-set-side-menu.component.scss
+++ b/src/components/data-set/data-set-side-menu/data-set-side-menu.component.scss
@@ -1,5 +1,6 @@
 $normalBackground: #525353;
 $hoveredBackground: #393838;
+$activeBackground: #313131;
 
 .dataset-sidemenu-container {
     display: flex;
@@ -70,8 +71,12 @@ $hoveredBackground: #393838;
     max-height: 5vh;
     flex: 1 1 100%;
     &:hover {
-        background-color: $normalBackground;
+        background-color: $hoveredBackground;
     }
+}
+
+.active {
+    background-color: $activeBackground;
 }
 
 .project-icon {

--- a/src/components/data-set/data-set-side-menu/data-set-side-menu.component.scss
+++ b/src/components/data-set/data-set-side-menu/data-set-side-menu.component.scss
@@ -113,5 +113,6 @@ $activeBackground: #313131;
     min-height: 0.3vh;
     max-height: 0.3vh;
     margin: auto;
+    margin-top: 1vh;
     border: 0.0625rem solid black;
 }

--- a/src/components/data-set/data-set-side-menu/data-set-side-menu.component.ts
+++ b/src/components/data-set/data-set-side-menu/data-set-side-menu.component.ts
@@ -18,6 +18,7 @@ type MenuSchema = {
     styleUrls: ['./data-set-side-menu.component.scss'],
 })
 export class DataSetSideMenuComponent implements OnInit {
+    selectedId: string = 'myproject';
     menuSchema: MenuSchema[] = [
         {
             src: '../../../assets/icons/add.svg',
@@ -32,7 +33,7 @@ export class DataSetSideMenuComponent implements OnInit {
         },
         {
             src: '../../../assets/icons/project.svg',
-            id: 'myProject',
+            id: 'myproject',
             name: 'menuName.myProject',
         },
         {
@@ -52,6 +53,7 @@ export class DataSetSideMenuComponent implements OnInit {
         },
     ];
     @Output() _onCreate: EventEmitter<boolean> = new EventEmitter();
+    @Output() _onFilter: EventEmitter<string> = new EventEmitter();
     @Output() _onImport = new EventEmitter();
 
     constructor() {}
@@ -63,6 +65,18 @@ export class DataSetSideMenuComponent implements OnInit {
     };
 
     onClickButton = (id: string): void => {
-        id === 'importProject' ? this._onImport.emit() : console.log('This feature is not available yet');
+        id !== 'importProject' && (this.selectedId = id);
+        switch (id) {
+            case 'importProject':
+                this._onImport.emit();
+                break;
+            case 'myproject':
+            case 'starred':
+            case 'recent':
+                this._onFilter.emit(id);
+                break;
+            default:
+                console.log('This feature is not available yet');
+        }
     };
 }

--- a/src/components/data-set/data-set-side-menu/data-set-side-menu.component.ts
+++ b/src/components/data-set/data-set-side-menu/data-set-side-menu.component.ts
@@ -46,11 +46,11 @@ export class DataSetSideMenuComponent implements OnInit {
             id: 'recent',
             name: 'menuName.recent',
         },
-        {
-            src: '../../../assets/icons/trash.svg',
-            id: 'trash',
-            name: 'menuName.trash',
-        },
+        // {
+        //     src: '../../../assets/icons/trash.svg',
+        //     id: 'trash',
+        //     name: 'menuName.trash',
+        // },
     ];
     @Output() _onCreate: EventEmitter<boolean> = new EventEmitter();
     @Output() _onFilter: EventEmitter<string> = new EventEmitter();

--- a/src/layouts/data-set-layout/data-set-layout.component.html
+++ b/src/layouts/data-set-layout/data-set-layout.component.html
@@ -5,9 +5,13 @@
 </div>
 <page-header [_onChange]="onChangeSchema"></page-header>
 <div class="upper-container">
-    <data-set-side-menu (_onCreate)="toggleModalDisplay($event)" (_onImport)="importProject()"></data-set-side-menu>
+    <data-set-side-menu
+        (_onCreate)="toggleModalDisplay($event)"
+        (_onImport)="importProject()"
+        (_onFilter)="filterProjects($event)"
+    ></data-set-side-menu>
     <div>
-        <data-set-header (selectedKey)="keyIsSelected($event)"></data-set-header>
+        <data-set-header (selectedKey)="keyIsSelected($event)" [_enableSort]="enableSort"></data-set-header>
         <data-set-card
             [_jsonSchema]="projectList"
             (_onClick)="onSubmit(false, $event)"

--- a/src/layouts/data-set-layout/data-set-layout.component.ts
+++ b/src/layouts/data-set-layout/data-set-layout.component.ts
@@ -182,19 +182,10 @@ export class DataSetLayoutComponent implements OnInit, OnDestroy {
                             this.sortedProject = formattedProjectList.filter((proj) => proj.is_starred);
                             break;
                         case 'recent':
-                            if (this.sortedProject.length > 10) {
-                                this.sortedProject = formattedProjectList
-                                    .sort((a, b) => (b.last_modified_timestamp > a.last_modified_timestamp ? 1 : -1))
-                                    .slice(0, 10);
-                            } else {
-                                this.sortedProject = formattedProjectList.sort((a, b) =>
-                                    b.last_modified_timestamp > a.last_modified_timestamp ? 1 : -1,
-                                );
-                                this.sortedProject = this.sortedProject.slice(
-                                    0,
-                                    Math.ceil(0.8 * this.sortedProject.length),
-                                );
-                            }
+                            this.sortedProject = formattedProjectList.sort((a, b) =>
+                                b.last_modified_timestamp > a.last_modified_timestamp ? 1 : -1,
+                            );
+                            this.sortedProject = this.sortedProject.slice(0, 6);
                             break;
                         default:
                             this.sortedProject = formattedProjectList;

--- a/src/layouts/data-set-layout/data-set-layout.component.ts
+++ b/src/layouts/data-set-layout/data-set-layout.component.ts
@@ -194,24 +194,18 @@ export class DataSetLayoutComponent implements OnInit, OnDestroy {
                     if (this.enableSort) {
                         switch (this.keyToSort) {
                             case 'project_name':
-                                this.sortedProject = this.sortedProject.sort((a, b) =>
-                                    b.project_name < a.project_name ? 1 : -1,
-                                );
+                                this.sortedProject.sort((a, b) => (b.project_name < a.project_name ? 1 : -1));
                                 break;
                             case 'created_date':
-                                this.sortedProject = this.sortedProject.sort((a, b) =>
-                                    b.created_timestamp > a.created_timestamp ? 1 : -1,
-                                );
+                                this.sortedProject.sort((a, b) => (b.created_timestamp > a.created_timestamp ? 1 : -1));
                                 break;
                             case 'last_modified_date':
-                                this.sortedProject = this.sortedProject.sort((a, b) =>
+                                this.sortedProject.sort((a, b) =>
                                     b.last_modified_timestamp > a.last_modified_timestamp ? 1 : -1,
                                 );
                                 break;
                             default:
-                                this.sortedProject = this.sortedProject.sort((a, b) =>
-                                    b.project_name < a.project_name ? 1 : -1,
-                                );
+                                this.sortedProject.sort((a, b) => (b.project_name < a.project_name ? 1 : -1));
                                 break;
                         }
                     }


### PR DESCRIPTION
# Description

- Show the project list based on the chosen category at side menu.
- 'My Project' shows all projects that have been created or imported.
- 'Starred' shows projects that have been starred. 
- Limit to 6 recent project (based on last modified) in 'Recent'.
  - Reason: 
    - Total project cards that can be fitted in a row in the lowest screen resolution (720p) is up to 6 cards.
    - A user might have a lot of projects (>100). User can just find the recent project quickly without scrolling down much. 
- Remove trash category, as the deleted project is not recoverable (deleted permanently).

https://user-images.githubusercontent.com/76939137/124253473-a3686700-db5a-11eb-93c4-ab905a64bcfd.mp4


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tested on?

- [x] Windows  
- [ ] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged