### PR TITLE
🐛  Not allowing UndoRedo when drawing ploygons

### DIFF
--- a/src/components/image-labelling/image-labelling-segmentation/image-labelling-segmentation.component.ts
+++ b/src/components/image-labelling/image-labelling-segmentation/image-labelling-segmentation.component.ts
@@ -85,7 +85,7 @@ export class ImageLabellingSegmentationComponent implements OnInit, OnChanges, O
         private _zoomService: ZoomService,
         private _mouseCursorService: MousrCursorService,
         private _shortcutKeyService: ShortcutKeyService,
-        private _sharedUndoRedoService: SharedUndoRedoService
+        private _sharedUndoRedoService: SharedUndoRedoService,
     ) {}
 
     ngOnInit(): void {
@@ -128,12 +128,12 @@ export class ImageLabellingSegmentationComponent implements OnInit, OnChanges, O
 
         this._sharedUndoRedoService.action.subscribe((message) => {
             switch (message) {
-              case 'SEG_UNDO':
-                this.undoAction();
-                break;
-              case 'SEG_REDO':
-                this.redoAction();
-                break;
+                case 'SEG_UNDO':
+                    this.undoAction();
+                    break;
+                case 'SEG_REDO':
+                    this.redoAction();
+                    break;
             }
         });
     }
@@ -330,9 +330,13 @@ export class ImageLabellingSegmentationComponent implements OnInit, OnChanges, O
             } else if (this._shortcutKeyService.checkKey(ctrlKey, metaKey, shiftKey, key, 'paste')) {
                 this.pastePolygon();
             } else if (this._shortcutKeyService.checkKey(ctrlKey, metaKey, shiftKey, key, 'redo')) {
-                this.redoAction();
+                if (!this._segCanvasService.isNewPolygon()) {
+                    this.redoAction();
+                }
             } else if (this._shortcutKeyService.checkKey(ctrlKey, metaKey, shiftKey, key, 'undo')) {
-                this.undoAction();
+                if (!this._segCanvasService.isNewPolygon()) {
+                    this.undoAction();
+                }
             }
             // }
         } catch (err) {
@@ -591,7 +595,12 @@ export class ImageLabellingSegmentationComponent implements OnInit, OnChanges, O
             // but mouse has already moving into canvas, thus getting error
             this.isMouseWithinPoint =
                 this._selectMetadata && this._segCanvasService.mouseClickWithinPointPath(this._selectMetadata, event);
-            if (this.isMouseWithinPoint && !this.showDropdownLabelBox && this.segState.draw && this.segState.crossLine) {
+            if (
+                this.isMouseWithinPoint &&
+                !this.showDropdownLabelBox &&
+                this.segState.draw &&
+                this.segState.crossLine
+            ) {
                 this.crossH.nativeElement.style.visibility = 'visible';
                 this.crossV.nativeElement.style.visibility = 'visible';
                 this.crossH.nativeElement.style.top = event.pageY.toString() + 'px';


### PR DESCRIPTION
# Description

Disable UndoRedo when drawing polygons

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


Uploading 2021-08-09 10-09-24.mp4…

0.09 -> Pressed Ctrl/Command + Z

# Tested on?

- [x] Windows  
- [ ] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  

# Checklist:

- [x] My code follows the style guidelines of this project
- [] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged