### PR TITLE
:bug: Use backspace to remove previous polygon point

### DIFF
--- a/src/components/image-labelling/image-labelling-segmentation/image-labelling-segmentation.component.ts
+++ b/src/components/image-labelling/image-labelling-segmentation/image-labelling-segmentation.component.ts
@@ -68,6 +68,7 @@ export class ImageLabellingSegmentationComponent implements OnInit, OnChanges, O
     labelSearch: string = '';
     labelList: LabelInfo[] = [];
     allLabelList: LabelInfo[] = [];
+    mouseEvent: MouseEvent | undefined;
     @Input() _selectMetadata!: PolyMetadata;
     @Input() _imgSrc: string = '';
     @Input() _tabStatus: TabsProps<CompleteMetadata>[] = [];
@@ -313,6 +314,9 @@ export class ImageLabellingSegmentationComponent implements OnInit, OnChanges, O
                         case 'Escape':
                             this.resetDrawingPolygon();
                             break;
+                        case 'Backspace':
+                            this.removeLastPointPolygon();
+                            break;
                     }
                 } else {
                     switch (key) {
@@ -366,6 +370,17 @@ export class ImageLabellingSegmentationComponent implements OnInit, OnChanges, O
             this.canvasContext,
             this.canvas.nativeElement,
         );
+    }
+
+    removeLastPointPolygon() {
+        this._segCanvasService.removeLastPoint(
+            this._selectMetadata,
+            this.canvasContext,
+            this.image,
+            this.canvas.nativeElement
+        );
+        this.redrawImage(this._selectMetadata);
+        this.mouseMoveDrawCanvas(this.mouseEvent as MouseEvent);
     }
 
     deletePolygon() {
@@ -627,6 +642,7 @@ export class ImageLabellingSegmentationComponent implements OnInit, OnChanges, O
                 }
                 if (this.segState.draw) {
                     // this._segCanvasService.setPanXY(event);
+                    this.mouseEvent = event;
                     const mouseWithinShape = this.mouseMoveDrawCanvas(event);
                     if (mouseWithinShape) {
                         this.crossH.nativeElement.style.visibility = 'hidden';


### PR DESCRIPTION
# Description

Use backspace to remove previous unwanted polygon point (Fix bug https://github.com/CertifaiAI/classifai/issues/486)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tested on?

- [x] Windows  
- [ ] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged