### PR TITLE
✨  Disable Create and Import Project button when in Docker Environment

### DIFF
--- a/src/components/data-set/data-set-side-menu/data-set-side-menu.component.ts
+++ b/src/components/data-set/data-set-side-menu/data-set-side-menu.component.ts
@@ -5,6 +5,7 @@
  */
 
 import { Component, EventEmitter, Output } from '@angular/core';
+import { DataSetLayoutComponent } from '../../../layouts/data-set-layout/data-set-layout.component';
 
 type MenuSchema = {
     src: string;
@@ -57,6 +58,9 @@ export class DataSetSideMenuComponent {
     @Output() _onImport = new EventEmitter();
 
     displayModal = (): void => {
+        if (DataSetLayoutComponent.prototype.isDockerEnv()) {
+            this._onCreate.emit(false);
+        }
         this._onCreate.emit(true);
     };
 

--- a/src/layouts/data-set-layout/data-set-layout.component.html
+++ b/src/layouts/data-set-layout/data-set-layout.component.html
@@ -169,7 +169,7 @@
                 <div class="select-file-container">
                     <label class="label-config">{{ 'importJson' | translate }} </label>
                     <div class="help-icon-container">
-                        <img class="help-icon" src="assets/icons/help.svg" alt="info"/>
+                        <img class="help-icon" src="assets/icons/help.svg" alt="info" />
                         <span class="tooltiptext">
                             <p>{{ 'configFileInfoDest1' | translate }}</p>
                             <p>{{ 'configFileInfoDest2' | translate }}</p>
@@ -177,7 +177,12 @@
                     </div>
                     <label class="choose-file-btn">
                         {{ 'chooseFile' | translate }}
-                        <button class="input-id" type="button" (click)="onSelectImportProjectJson()">
+                        <button
+                            class="input-id"
+                            type="button"
+                            (click)="onSelectImportProjectJson()"
+                            [disabled]="isDockerEnv()"
+                        >
                             {{ 'Import' }}
                         </button>
                     </label>
@@ -207,7 +212,9 @@
 >
     <div class="display-modal-container">
         <p class="display-msg">
-            {{ projectName }} {{ 'renameMsg' | translate }} <strong class="validation-success">{{ 'success' | translate }}</strong>!
+            {{ projectName }} {{ 'renameMsg' | translate }}
+            <strong class="validation-success">{{ 'success' | translate }}</strong
+            >!
         </p>
     </div>
 </modal>
@@ -218,11 +225,8 @@
     [modalTitle]="'deleteProject' | translate"
     [scrollable]="false"
 >
-
     <div class="display-modal-container" *ngIf="!isDeleteSuccess">
-        <p class="display-msg">
-            {{ 'deleteConfirmation' | translate }} {{ projectName }} ?
-        </p>
+        <p class="display-msg">{{ 'deleteConfirmation' | translate }} {{ projectName }} ?</p>
         <div class="model-button-container">
             <button class="button-style create-btn" type="submit" (click)="confirmDeleteProject()">
                 {{ 'confirm' | translate }}
@@ -231,7 +235,9 @@
     </div>
     <div class="display-modal-container" *ngIf="isDeleteSuccess">
         <p class="display-msg">
-            {{ projectName }} {{ 'deleteMsg' | translate }} <strong class="validation-success">{{ 'success' | translate }}</strong>!
+            {{ projectName }} {{ 'deleteMsg' | translate }}
+            <strong class="validation-success">{{ 'success' | translate }}</strong
+            >!
         </p>
     </div>
 </modal>

--- a/src/layouts/data-set-layout/data-set-layout.component.ts
+++ b/src/layouts/data-set-layout/data-set-layout.component.ts
@@ -7,7 +7,13 @@
 import { cloneDeep } from 'lodash-es';
 import { Component, ElementRef, HostListener, OnDestroy, OnInit, ViewChild } from '@angular/core';
 import { DataSetLayoutService } from './data-set-layout-api.service';
-import { DataSetProps, Project, ProjectRename, ProjectSchema, StarredProps } from '../../shared/types/dataset-layout/data-set-layout.model';
+import {
+    DataSetProps,
+    Project,
+    ProjectRename,
+    ProjectSchema,
+    StarredProps,
+} from '../../shared/types/dataset-layout/data-set-layout.model';
 import { distinctUntilChanged, first, map, mergeMap, switchMap, takeUntil } from 'rxjs/operators';
 import { interval, Observable, Subject, Subscription, throwError } from 'rxjs';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
@@ -32,6 +38,7 @@ type FormattedProject = {
     is_new: boolean;
     total_uuid: number;
     root_path_valid: boolean;
+    is_docker: boolean;
 };
 
 @Component({
@@ -621,29 +628,29 @@ export class DataSetLayoutComponent implements OnInit, OnDestroy {
     };
 
     deleteProject = (projectName: string): void => {
-      this.isDeleteSuccess = false;
-      this.projectName = projectName;
-      this._languageService._translate.get('deleteSuccess').subscribe((translated) => {
+        this.isDeleteSuccess = false;
         this.projectName = projectName;
-        this._modalService.open(this.modalIdDeleteProject);
-    });
+        this._languageService._translate.get('deleteSuccess').subscribe((translated) => {
+            this.projectName = projectName;
+            this._modalService.open(this.modalIdDeleteProject);
+        });
     };
 
     confirmDeleteProject = (): void => {
-      const deleteProj$ = this._dataSetService.deleteProject(this.projectName);
+        const deleteProj$ = this._dataSetService.deleteProject(this.projectName);
 
-      deleteProj$
-          .pipe(
-              first(),
-              map(({ message }) => message),
-          )
-          .subscribe((message) => {
-              if (message === 1) {
-                  this.isDeleteSuccess = true;
-                  this.showProjectList(this.projectType);
-              }
-          });
-    }
+        deleteProj$
+            .pipe(
+                first(),
+                map(({ message }) => message),
+            )
+            .subscribe((message) => {
+                if (message === 1) {
+                    this.isDeleteSuccess = true;
+                    this.showProjectList(this.projectType);
+                }
+            });
+    };
 
     @HostListener('window:keydown', ['$event'])
     keyDownEvent = ({ key }: KeyboardEvent): void => {
@@ -662,5 +669,16 @@ export class DataSetLayoutComponent implements OnInit, OnDestroy {
     ngOnDestroy(): void {
         this.unsubscribe$.next();
         this.unsubscribe$.complete();
+    }
+
+    isDockerEnv() {
+        const listProjectMetaData: Project[] = this.projectList.projects;
+
+        for (const i in listProjectMetaData) {
+            if (listProjectMetaData[i].is_docker) {
+                this.toggleImportProjectModalDisplay(false);
+                return true;
+            }
+        }
     }
 }

--- a/src/shared/types/dataset-layout/data-set-layout.model.ts
+++ b/src/shared/types/dataset-layout/data-set-layout.model.ts
@@ -52,6 +52,7 @@ export type Project = {
     created_timestamp: Date;
     last_modified_timestamp: Date;
     root_path_valid: boolean;
+    is_docker: boolean;
 };
 
 export type ProjectSchema = {
@@ -61,15 +62,17 @@ export type ProjectSchema = {
 };
 
 /** @type mainly used for passing props with generic type while ability to allow conditional of generic type usage */
-export type DataSetProps<T = undefined> = {} | (T extends undefined
-    ? {
-          // theme: string;
-          status?: boolean;
-          currentThumbnailIndex: number;
-          totalNumThumbnail: number;
-          thumbnailName: string | undefined;
-      }
-    : T);
+export type DataSetProps<T = undefined> =
+    | {}
+    | (T extends undefined
+          ? {
+                // theme: string;
+                status?: boolean;
+                currentThumbnailIndex: number;
+                totalNumThumbnail: number;
+                thumbnailName: string | undefined;
+            }
+          : T);
 
 export type FileType = 'file' | 'folder';
 


### PR DESCRIPTION
# Description

When Classifai deploys in the Docker container, Users will not be allowed to click the New project and Import Project button due to the dataset files are shared in the mount volume.

Kindly use this branch for testing because this branch will be subjected to review before merge to main.
[https://github.com/CertifaiAI/classifai/tree/ken_dockerStatus](url)

Reminder:
Wait for [#497](https://github.com/CertifaiAI/classifai/pull/497) merge, then only approve this PR. Thank you

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tested on?

- [x] Windows  
- [ ] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  

# Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged